### PR TITLE
Display 1 over length of duration as well as in samples

### DIFF
--- a/src/gui.hpp
+++ b/src/gui.hpp
@@ -30,7 +30,7 @@ class Gui : public Gtk::Window {
     void UpdateZoom();
     void UpdateFrequency();
     void UpdateTitle();
-    Glib::ustring FormatTime(float t, bool show_minutes = true);
+    
     Gtk::HeaderBar headerbar;
     Gtk::Button open;
     Gtk::VBox box;

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -240,3 +240,7 @@ void State::ResetView() {
         }
     }
 }
+
+int State::GetCurrentSamplerate() {
+    return GetSelectedTrack().GetSamplerate();
+}

--- a/src/state.hpp
+++ b/src/state.hpp
@@ -28,6 +28,10 @@ struct Track {
     std::future<std::unique_ptr<Spectrogram>> future_spectrogram;
     bool reload = false;
     bool remove = false;
+
+    int GetSamplerate() {
+        return audio_buffer->Samplerate();
+    }
 };
 
 class State {
@@ -59,6 +63,7 @@ class State {
     Track& GetTrack(int number);
     Track& GetSelectedTrack();
     void ResetView();
+    int GetCurrentSamplerate();
 
     std::list<Track> tracks;
     ZoomWindow zoom_window;


### PR DESCRIPTION
To help debugging certain type of audio issue, it is useful to know the
duration in samples as well as its corresponding frequency.